### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - "2.1.1"
+script: bundle exec rspec spec
+before_script:
+  - wget http://download.nanomsg.org/nanomsg-0.3-beta.tar.gz -O /tmp/nanomsg-0.3-beta.tar.gz
+  - tar -xzf /tmp/nanomsg-0.3-beta.tar.gz
+  - cd nanomsg-0.3-beta && ./configure && sudo make install && sudo ldconfig && cd ${TRAVIS_BUILD_DIR}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 nn-core
 -------
 
+[![Build Status](https://travis-ci.org/chuckremes/nn-core.svg?branch=master)](https://travis-ci.org/chuckremes/nn-core)
+
 nn-core is a very thin FFI wrapper around the nanomsg library. The intention is to provide a very
 simple wrapper that hews as close to the C API as possible. Other gems that want to offer a more
 idiomatic API for Ruby should require this gem and build a nice Ruby API with it.


### PR DESCRIPTION
I have tested this in my own branch. If you merge this you'll have to flip the switch on travis-ci.org first for this project.

I am also unsure which ruby versions should be supported. Haven't read on that for FFI yet.

Also, should we test against the latest release or against nanomsg master? I would like to make a failing test for nn_poll but the nn_errno is broken in 0.3 and has been fixed in master. ( https://github.com/nanomsg/nanomsg/commit/9f0e4a8be1f4a9f8418ef3252380ab7b9e837155 )
