### PR TITLE
Build libnanomsg during gem install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/*
 
 *.rbc
 .redcar/
+ext/nanomsg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ rvm:
 script: bundle exec rspec spec
 matrix:
   allow_failures:
-before_install:
-  - git clone git://github.com/nanomsg/nanomsg.git
-  - cd nanomsg && ./autogen.sh && ./configure && sudo make install && sudo ldconfig && cd ${TRAVIS_BUILD_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ rvm:
 script: bundle exec rspec spec
 matrix:
   allow_failures:
+before_install: pushd ext && bundle exec rake && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ rvm:
 script: bundle exec rspec spec
 matrix:
   allow_failures:
-before_install: pushd ext && bundle exec rake && popd
+before_install: pushd ext && rake && popd

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-nn-core
--------
+# nn-core
 
 [![Build Status](https://travis-ci.org/chuckremes/nn-core.svg?branch=master)](https://travis-ci.org/chuckremes/nn-core)
 
@@ -11,29 +10,41 @@ For more information on nanomsg, please visit its website:
 
 http://nanomsg.org
 
-Installation
-------------
+# Bundler Installation
 
-1. Make sure to build libnanomsg first by following these instructions:
+1. Add this line to your `Gemfile`:
 
-http://github.com/250bpm/nanomsg
+    gem 'nn-core'
 
-2. git clone git://github.com/chuckremes/nn-core.git
+2. Install the gem using bundler:
 
-3. cd nn-core
+    bundle install
 
-4. ruby -S gem build nn-core.gemspec
+3. In your code, do:
 
-5. ruby -S gem install nn-core*.gem
+    ```ruby
+    require "nn-core"
+    ```
 
-6. In your code, do:
+# Manual Installation
 
-```ruby
-require "nn-core"
-```
+1. Clone this repository
 
-License
--------
+    git clone https://github.com/chuckremes/nn-core.git
+
+2. Install the gem dependencies:
+
+    bundle install
+
+3. Build libnanomsg:
+
+    pushd ext && bundle exec rake && popd
+
+4. Run the tests to ensure everything works fine:
+
+    bundle exec rake spec
+
+# License
 
 (The MIT License)
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ http://nanomsg.org
 
 1. Add this line to your `Gemfile`:
 
+    ```ruby
     gem 'nn-core'
+    ```
 
 2. Install the gem using bundler:
 
+    ```shell
     bundle install
+    ```
 
 3. In your code, do:
 
@@ -30,19 +34,27 @@ http://nanomsg.org
 
 1. Clone this repository
 
+    ```shell
     git clone https://github.com/chuckremes/nn-core.git
+    ```
 
 2. Install the gem dependencies:
 
+    ```shell
     bundle install
+    ```
 
 3. Build libnanomsg:
 
-    pushd ext && bundle exec rake && popd
+    ```shell
+    pushd ext && rake && popd
+    ```
 
 4. Run the tests to ensure everything works fine:
 
+    ```shell
     bundle exec rake spec
+    ```
 
 # License
 

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,0 +1,5 @@
+desc "Compile the nanomsg native C library"
+task :default do
+  system("git clone https://github.com/nanomsg/nanomsg.git")
+  system("cd nanomsg && git checkout 0.5-beta && ./autogen.sh && ./configure && make")
+end

--- a/lib/nn-core/libnanomsg.rb
+++ b/lib/nn-core/libnanomsg.rb
@@ -6,7 +6,7 @@ module NNCore
     begin
       # bias the library discovery to a path inside the gem first, then
       # to the usual system paths
-      inside_gem = File.join(File.dirname(__FILE__), '..', '..', 'ext')
+      inside_gem = File.join(File.dirname(__FILE__), '..', '..', 'ext', 'nanomsg', '.libs')
       local_path = FFI::Platform::IS_WINDOWS ? ENV['PATH'].split(';') : ENV['PATH'].split(':')
       library_name = "libnanomsg"
       LIB_PATHS = [

--- a/nn-core.gemspec
+++ b/nn-core.gemspec
@@ -22,5 +22,6 @@ to build an API using Ruby idioms.}
 
   s.add_runtime_dependency "ffi"
   s.add_development_dependency "rspec", ["~> 3.2"]
-  s.add_development_dependency "rake"
+  s.add_dependency "rake"
+  s.extensions = %w(ext/Rakefile)
 end


### PR DESCRIPTION
Hi,

I thought it would be convenient if the `libnanomsg` C extension could be built during `bundle install` or `gem install`.

I also slightly updated the documentation :palm_tree: 
